### PR TITLE
Add paibot2 scraper service

### DIFF
--- a/paibot2/app.py
+++ b/paibot2/app.py
@@ -1,0 +1,26 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.post('/scrape')
+def scrape():
+    data = request.get_json(force=True) or {}
+    query = data.get('url', '')
+
+    # Placeholder implementation - in real life we'd scrape or query a chatbot
+    result = {
+        'siret': '00000000000000',
+        'siren': '000000000',
+        'naf_ape': '0000Z',
+        'raison_sociale': 'Placeholder Corp',
+        'adresse_siege': '1 rue Exemple, 75000 Paris'
+    }
+
+    # Incorporate query as context if present
+    if query:
+        result['source_query'] = query
+
+    return jsonify(result)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)


### PR DESCRIPTION
## Summary
- add `paibot2/` with a minimal Flask app
- expose `POST /scrape` returning placeholder company info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas', 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6846e26c4b108333bbd936356e954764