### PR TITLE
Fix .gitignore comment formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-venv# Ignore Python environments & cache
+# Ignore Python environments & cache
 venv/
 __pycache__/
 *.pyc


### PR DESCRIPTION
## Summary
- separate header comment from first ignore pattern
- ensure `.gitignore` ends with a newline

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846e26eb4088333a1b4bf3289b45019