### PR TITLE
Fix dynamic scraping in microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Picasee fait correspondre associations et entreprises à impact social.
 1. **Prérequis** : Python 3.12+.
 2. Installez les dépendances nécessaires :
    ```bash
-   pip install flask requests geopy pandas scikit-learn matplotlib pyyaml
+   pip install flask requests geopy pandas scikit-learn matplotlib pyyaml beautifulsoup4
    ```
 
 ## Lancer l'application

--- a/tests/test_scraper_service.py
+++ b/tests/test_scraper_service.py
@@ -27,23 +27,67 @@ flask_stub.jsonify = lambda x: x
 
 sys.modules.setdefault('flask', flask_stub)
 
+# Minimal BeautifulSoup stub for tests
+bs4_stub = types.ModuleType('bs4')
+
+def _fake_bs(html, parser='html.parser'):
+    class _Soup:
+        def __init__(self, html):
+            self._html = html
+
+        def find(self, tag, id=None):
+            if tag == 'script' and id == '__NEXT_DATA__':
+                start = self._html.find('{')
+                end = self._html.rfind('}')
+                if start != -1 and end != -1:
+                    return types.SimpleNamespace(string=self._html[start:end + 1])
+            return None
+
+    return _Soup(html)
+
+bs4_stub.BeautifulSoup = _fake_bs
+sys.modules.setdefault('bs4', bs4_stub)
+
 app = import_module('app')
 
 
 def test_scrape_by_name(monkeypatch):
-    dummy_data = {
-        'unites_legales': [{
-            'siren': '552081317',
-            'siret_siege': '55208131700017',
-            'denomination': 'THALES',
-            'activite_principale': '2611Z',
-            'numero_voie': '10',
-            'type_voie': 'RUE',
-            'libelle_voie': 'DE GRENELLE',
-            'code_postal': '75015',
-            'libelle_commune': 'PARIS'
-        }]
-    }
+    html = """
+    <html><head></head><body>
+    <script id="__NEXT_DATA__" type="application/json">
+    {"props": {"pageProps": {"entreprise": {
+        "siren": "552081317",
+        "siret_siege": "55208131700017",
+        "denomination": "THALES",
+        "activite_principale": "2611Z",
+        "numero_voie": "10",
+        "type_voie": "RUE",
+        "libelle_voie": "DE GRENELLE",
+        "code_postal": "75015",
+        "libelle_commune": "PARIS"
+    }}}}
+    </script></body></html>
+    """
+
+    class DummyResp:
+        def __init__(self, text):
+            self.text = text
+
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, params=None, timeout=10):
+        return DummyResp(html)
+
+    monkeypatch.setattr(app.requests, 'get', fake_get)
+    data = app._fetch_company_info('Thales')
+    assert data['siren'] == '552081317'
+    assert data['siret_siege'] == '55208131700017'
+    assert data['denomination'] == 'THALES'
+
+
+def test_fetch_by_number(monkeypatch):
+    dummy = {'etablissement': {'siret': '12345678900011'}}
 
     class DummyResp:
         def __init__(self, data):
@@ -55,12 +99,10 @@ def test_scrape_by_name(monkeypatch):
         def json(self):
             return self._data
 
-    def fake_get(url, params=None, timeout=10):
-        assert 'unites_legales' in url
-        return DummyResp(dummy_data)
+    def fake_get(url, timeout=10, params=None):
+        assert 'etablissements' in url
+        return DummyResp(dummy)
 
     monkeypatch.setattr(app.requests, 'get', fake_get)
-    data = app._fetch_company_info('Thales')
-    assert data['siren'] == '552081317'
-    assert data['siret_siege'] == '55208131700017'
-    assert data['denomination'] == 'THALES'
+    data = app._fetch_company_info('12345678900011')
+    assert data['siret'] == '12345678900011'


### PR DESCRIPTION
## Summary
- add BeautifulSoup-based HTML scraping for annuaire-entreprises
- use scraped data in `_fetch_company_info` with API fallback
- provide BeautifulSoup test stub and update README dependencies
- adjust scraper tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e8c055b883338e246ee1cdba5616